### PR TITLE
feat: Add priority indicators and task detail view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -463,29 +463,47 @@ body {
   transition: background-color 0.3s ease;
 }
 
-.task-item.priority-low::before {
+.task-item.has-tag::before {
+  background-color: var(--tag-color, var(--primary-color));
+}
+
+.task-meta-info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--archived-text);
+}
+
+.task-due-date, .task-recurrence, .task-priority-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.task-priority-indicator {
+  padding: 0.1rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--pure-white);
+}
+
+.task-priority-indicator.priority-low {
   background-color: var(--priority-low);
 }
-
-.task-item.priority-medium::before {
+.task-priority-indicator.priority-medium {
   background-color: var(--priority-medium);
 }
-
-.task-item.priority-high::before {
+.task-priority-indicator.priority-high {
   background-color: var(--priority-high);
 }
 
-.task-item.has-tag::before {
-  background-color: var(--tag-color, var(--primary-color)) !important;
-}
-
-.task-due-date {
-  font-size: 0.8rem;
-  color: var(--archived-text);
-  margin-top: 0.25rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+.task-due-date.overdue {
+  color: var(--accent-color);
+  font-weight: 500;
 }
 
 .task-due-date.overdue {
@@ -953,6 +971,48 @@ dialog.confirmation-dialog::backdrop {
   font-size: 0.8rem;
   cursor: pointer;
   font-weight: bold;
+}
+
+/* View Task Dialog */
+#view-task-dialog .dialog-content {
+  max-width: 500px;
+}
+
+.view-task-section {
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 1rem;
+}
+
+.view-task-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+#view-task-description {
+  line-height: 1.6;
+  white-space: pre-wrap; /* Preserve line breaks from textarea */
+  word-wrap: break-word;
+}
+
+#view-task-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+#view-task-tags-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+#view-task-dialog h4 {
+  margin: 0 0 0.5rem 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
 }
 
 /* Diálogo de Gerenciar Tags */

--- a/index.html
+++ b/index.html
@@ -400,6 +400,30 @@
 
   <div id="sidebar-overlay" class="sidebar-overlay"></div>
 
+  <div id="view-task-dialog" class="dialog hidden">
+    <div class="dialog-content">
+      <div class="dialog-header">
+        <h2 id="view-task-title"></h2>
+        <button id="close-view-task-dialog-btn" class="close-button">&times;</button>
+      </div>
+      <div class="dialog-body">
+        <div id="view-task-description" class="view-task-section">
+          <!-- Full description will be here -->
+        </div>
+        <div id="view-task-meta" class="view-task-section">
+          <!-- Meta info will be here -->
+        </div>
+        <div id="view-task-tags" class="view-task-section">
+          <h4>Tags</h4>
+          <div id="view-task-tags-container"></div>
+        </div>
+      </div>
+      <div class="dialog-footer">
+        <button type="button" id="view-task-edit-btn" class="button primary">Editar Tarefa</button>
+      </div>
+    </div>
+  </div>
+
   <div id="notification-container" class="notification-container"></div>
   </div>
 </body>

--- a/js/modules/dialogs.js
+++ b/js/modules/dialogs.js
@@ -124,4 +124,66 @@ export class DialogManager {
   closeExportDialog() {
     elements.exportDialog.classList.add('hidden');
   }
+
+  /**
+   * Abre o diálogo de visualização de tarefa
+   */
+  openViewTaskDialog(taskId) {
+    const task = storage.getTasks().find(t => t.id === taskId);
+    if (!task) return;
+
+    elements.viewTaskTitle.textContent = task.title;
+    elements.viewTaskDescription.textContent = task.description || 'Nenhuma descrição fornecida.';
+
+    // Construir meta info
+    elements.viewTaskMeta.innerHTML = '';
+    if (task.priority) {
+      elements.viewTaskMeta.innerHTML += `
+        <div class="task-priority-indicator priority-${task.priority}">
+          Prioridade: ${utils.getPriorityText(task.priority)}
+        </div>`;
+    }
+    if (task.dueDate) {
+      elements.viewTaskMeta.innerHTML += `
+        <div class="task-due-date ${utils.isOverdue(task.dueDate) ? 'overdue' : ''}">
+          Vence em: ${utils.formatDueDate(task.dueDate)}
+        </div>`;
+    }
+    if (task.recurrence && task.recurrence !== 'none') {
+      elements.viewTaskMeta.innerHTML += `
+        <div class="task-recurrence">
+          Recorrência: ${utils.getRecurrenceText(task.recurrence)}
+        </div>`;
+    }
+
+    // Construir tags
+    elements.viewTaskTagsContainer.innerHTML = '';
+    if (task.tags && task.tags.length > 0) {
+      const allTags = storage.getTags();
+      task.tags.forEach(tagId => {
+        const tag = allTags.find(t => t.id === tagId);
+        if (tag) {
+          const tagEl = document.createElement('span');
+          tagEl.className = 'tag';
+          tagEl.textContent = tag.name;
+          tagEl.style.backgroundColor = tag.color;
+          elements.viewTaskTagsContainer.appendChild(tagEl);
+        }
+      });
+    } else {
+      elements.viewTaskTagsContainer.innerHTML = '<p>Nenhuma tag associada.</p>';
+    }
+
+    // Armazenar o ID da tarefa para o botão de editar
+    elements.viewTaskEditBtn.dataset.taskId = taskId;
+
+    elements.viewTaskDialog.classList.remove('hidden');
+  }
+
+  /**
+   * Fecha o diálogo de visualização de tarefa
+   */
+  closeViewTaskDialog() {
+    elements.viewTaskDialog.classList.add('hidden');
+  }
 }

--- a/js/modules/dom-elements.js
+++ b/js/modules/dom-elements.js
@@ -97,5 +97,14 @@ export const elements = {
   closeExportDialogBtn: document.getElementById('close-export-dialog-btn'),
   exportCurrentListBtn: document.getElementById('export-current-list-btn'),
   exportAllListsBtn: document.getElementById('export-all-lists-btn'),
-  cancelExportBtn: document.getElementById('cancel-export-btn')
+  cancelExportBtn: document.getElementById('cancel-export-btn'),
+
+  // Diálogo de visualização de tarefa
+  viewTaskDialog: document.getElementById('view-task-dialog'),
+  closeViewTaskDialogBtn: document.getElementById('close-view-task-dialog-btn'),
+  viewTaskTitle: document.getElementById('view-task-title'),
+  viewTaskDescription: document.getElementById('view-task-description'),
+  viewTaskMeta: document.getElementById('view-task-meta'),
+  viewTaskTagsContainer: document.getElementById('view-task-tags-container'),
+  viewTaskEditBtn: document.getElementById('view-task-edit-btn')
 };

--- a/js/modules/tasks.js
+++ b/js/modules/tasks.js
@@ -92,9 +92,6 @@ export class TaskManager {
     taskEl.classList.toggle('completed', task.completed);
     taskEl.classList.toggle('favorited', task.favorited);
     taskEl.classList.toggle('archived', task.archived);
-    if (task.priority) {
-      taskEl.classList.add(`priority-${task.priority}`);
-    }
     taskEl.dataset.taskId = task.id;
 
     const tags = storage.getTags();
@@ -113,30 +110,50 @@ export class TaskManager {
       return tag ? `<span class="tag clickable" style="background-color: ${tag.color};" data-tag-id="${tag.id}">${tag.name}</span>` : '';
     }).join('');
 
-    const descriptionHtml = task.description ? `<div class="task-description">${task.description}</div>` : '';
+    const descriptionHtml = task.description ? `<div class="task-description">${utils.truncateText(task.description, 100)}</div>` : '';
+
+    const priorityHtml = task.priority ? `
+      <div class="task-priority-indicator priority-${task.priority}">
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+        </svg>
+        ${utils.getPriorityText(task.priority)}
+      </div>
+    ` : '';
+
+    const dueDateHtml = task.dueDate ? `
+      <div class="task-due-date ${utils.isOverdue(task.dueDate) ? 'overdue' : ''}">
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"></circle>
+          <polyline points="12 6 12 12 16 14"></polyline>
+        </svg>
+        ${utils.formatDueDate(task.dueDate)}
+      </div>
+    ` : '';
+
+    const recurrenceHtml = task.recurrence && task.recurrence !== 'none' ? `
+      <div class="task-recurrence">
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.3"/>
+        </svg>
+        ${utils.getRecurrenceText(task.recurrence)}
+      </div>
+    ` : '';
+
+    const metaInfoHtml = priorityHtml || dueDateHtml || recurrenceHtml ? `
+      <div class="task-meta-info">
+        ${priorityHtml}
+        ${dueDateHtml}
+        ${recurrenceHtml}
+      </div>
+    ` : '';
 
     taskEl.innerHTML = `
       <input type="checkbox" class="task-checkbox" ${task.completed ? 'checked' : ''}>
       <div class="task-content">
         <div class="task-title-text">${task.title}</div>
         ${descriptionHtml}
-        ${task.dueDate ? `
-          <div class="task-due-date ${utils.isOverdue(task.dueDate) ? 'overdue' : ''}">
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="10"></circle>
-              <polyline points="12 6 12 12 16 14"></polyline>
-            </svg>
-            ${utils.formatDueDate(task.dueDate)}
-          </div>
-        ` : ''}
-        ${task.recurrence && task.recurrence !== 'none' ? `
-          <div class="task-recurrence">
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.3"/>
-            </svg>
-            ${utils.getRecurrenceText(task.recurrence)}
-          </div>
-        ` : ''}
+        ${metaInfoHtml}
         <div class="task-tags">${taskTagsHtml}</div>
       </div>
       <div class="task-actions">

--- a/js/modules/utils.js
+++ b/js/modules/utils.js
@@ -34,6 +34,18 @@ export const utils = {
   },
 
   /**
+   * Obtém o texto de prioridade
+   */
+  getPriorityText: (priority) => {
+    const priorityMap = {
+      low: 'Baixa',
+      medium: 'Média',
+      high: 'Alta'
+    };
+    return priorityMap[priority] || '';
+  },
+
+  /**
    * Exibe uma notificação
    */
   showNotification: (message, type = 'success') => {
@@ -64,5 +76,15 @@ export const utils = {
     if (savedTheme) {
       document.documentElement.setAttribute('data-theme', savedTheme);
     }
+  },
+
+  /**
+   * Trunca um texto se for maior que o tamanho máximo
+   */
+  truncateText: (text, maxLength) => {
+    if (text.length <= maxLength) {
+      return text;
+    }
+    return text.slice(0, maxLength) + '...';
   }
 };

--- a/js/script.js
+++ b/js/script.js
@@ -107,6 +107,14 @@ document.addEventListener('DOMContentLoaded', () => {
     utils.showNotification(id ? 'Tarefa atualizada!' : 'Tarefa adicionada!', 'success');
   });
 
+  // Diálogo de visualização de tarefa
+  elements.closeViewTaskDialogBtn.addEventListener('click', () => dialogManager.closeViewTaskDialog());
+  elements.viewTaskEditBtn.addEventListener('click', (e) => {
+    const taskId = e.target.dataset.taskId;
+    dialogManager.closeViewTaskDialog();
+    dialogManager.openTaskDialog('edit', taskId);
+  });
+
   // Event listeners para ações das tarefas
   elements.tasksListContainer.addEventListener('click', (e) => {
     const target = e.target;
@@ -143,6 +151,10 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (target.closest('.delete-btn')) {
       taskManager.taskToDeleteId = taskId;
       elements.confirmDialog.classList.remove('hidden');
+      return;
+    } else if (target.closest('.task-content')) {
+      // Abre o diálogo de visualização se clicar no conteúdo da tarefa
+      dialogManager.openViewTaskDialog(taskId);
       return;
     } else {
       return;


### PR DESCRIPTION
This commit introduces two new user-facing features based on feedback:
1. Adds a clear visual indicator for task priority.
2. Implements a popup dialog to view the full details of a task.

Feature Details:
- **Visual Priority Indicator:**
  - Each task in the list now displays a colored pill (e.g., "High", "Medium", "Low") to clearly indicate its priority.
  - This replaces the previous, less obvious method of using a colored border, which would conflict with tag colors.

- **Task Details Popup:**
  - Long task descriptions are now truncated in the main list view.
  - Clicking on the content of a task opens a new read-only dialog.
  - This dialog displays the task's full title, description, priority, due date, recurrence, and tags.
  - An "Edit" button in the dialog provides a convenient shortcut to the existing edit screen.